### PR TITLE
Only add missing paths during init.

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,3 +1,9 @@
 set -q PLENV_ROOT; or set -l PLENV_ROOT $HOME/.plenv
 
-set PATH $PLENV_ROOT/shims $PLENV_ROOT/bin $PATH
+if not contains $PLENV_ROOT/bin $PATH
+  set PATH $PLENV_ROOT/bin $PATH
+end
+
+if not contains $PLENV_ROOT/shims $PATH
+  set PATH $PLENV_ROOT/shims $PATH
+end


### PR DESCRIPTION
This prevents issues when reloading the shell. See oh-my-fish/plugin-composer#7
